### PR TITLE
Added conditional comment "IE=edge" meta

### DIFF
--- a/boilerplate.html
+++ b/boilerplate.html
@@ -5,7 +5,9 @@
     <title>Email Framework Version 1.0.1</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
     
     <!-- Demo Only -->
     <link rel="stylesheet" href="mail.css" type="text/css" />


### PR DESCRIPTION
```
<meta http-equiv="X-UA-Compatible" content="IE=edge" />
```

is used here so that Windows Phones will display our mobile version correctly.
But it should be hidden inside a conditional comment like this:

```
<!--[if !mso]><!-->
<meta http-equiv="X-UA-Compatible" content="IE=edge" />
<!--<![endif]-->
```

that hides it from any 'mso' (Microsoft Outlook) products to prevent a problem where Windows Live Mail will not display images when this tag is used.

Source and more detail on [tutsplus.com](http://webdesign.tutsplus.com/tutorials/creating-a-future-proof-responsive-email-without-media-queries--cms-23919#comment-2068661996)
