### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 The HTML Email Framework developed to help you build responsive HTML email templates.
 
-###Getting Started
+### Getting Started
 
 * [Documentation](http://emailframe.work "Title")
 * [Download](https://github.com/g13nn/Email-Framework/archive/master.zip "Title")
 
-###Support
+### Support
 
 Need some help, or have a question.  Get in touch:
 
 * <hello@glennsmith.me>
 * [Submit an Issue](https://github.com/g13nn/Email-Framework/issues/new "Title")
 
-###License
+### License
 
 ```
 Copyright (C) 2017 Glenn Smith


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
