### PR TITLE
Add color-scheme support

### DIFF
--- a/boilerplate.html
+++ b/boilerplate.html
@@ -4,6 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">  
 
   <title></title>
 

--- a/grids/fluid/fluid-grid-master.html
+++ b/grids/fluid/fluid-grid-master.html
@@ -4,6 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
 
   <title>Fluid Grid Master</title>
 

--- a/grids/hybrid/hybrid-grid-master.html
+++ b/grids/hybrid/hybrid-grid-master.html
@@ -2,6 +2,8 @@
 <html>
 <head>
 <meta charset="UTF-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>Hybrid Grid Master</title>
 <style type="text/css">
 

--- a/grids/responsive/responsive-grid-master.html
+++ b/grids/responsive/responsive-grid-master.html
@@ -4,6 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
 
   <title>Grids Master Template</title>
 


### PR DESCRIPTION
Adds meta tags informing that the email supports light and dark modes.
This keeps text and background colors on both modes.